### PR TITLE
docs: add templates and cointributing guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug-issue.md
+++ b/.github/ISSUE_TEMPLATE/00-bug-issue.md
@@ -1,0 +1,23 @@
+---
+name: Bug Issue
+about: Use this template for reporting a bug
+labels: 'type:bug'
+
+---
+
+<em>tag:bug_template</em>
+
+**System information**
+- OS Platform and Distribution (e.g., Linux Ubuntu 16.04):
+
+**Describe the current behavior**
+
+**Describe the expected behavior**
+
+**Standalone code to reproduce the issue**
+Provide a reproducible test case that is the bare minimum necessary to generate
+the problem.
+
+**Other info / logs** Include any logs or source code that would be helpful to
+diagnose the problem. If including tracebacks, please include the full
+traceback. Large logs and files should be attached.

--- a/.github/ISSUE_TEMPLATE/10-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/10-feature-request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Use this template for raising a feature request
+labels: 'type:feature'
+
+---
+
+<em>tag:feature_template</em>
+
+
+**System information**
+- Are you willing to contribute it (Yes/No):
+
+**Describe the feature and the current behavior/state.**
+
+**Will this change the current api? How?**
+
+**Who will benefit with this feature?**
+
+**Any Other info.**

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,23 @@
+Thanks for contributing! Please ensure your pull request adheres to the following guidelines:
+
+- [ ] Use the following format: `[CONTRIBUTING](https://github.com/YiGu-Studio/MB2CommunityEditor/CONTRIBUTING.md)`
+- [ ] Your Code has been sorted and formatted.
+- [ ] Your Code is runable at least on your local machine.
+
+**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
+
+Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.
+
+# Summary
+
+Please provide enough information so that others can review your pull request:
+
+Explain the details for making this change. What existing problem does the pull request solve?
+
+# Test Plan
+
+Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
+
+## Closing issues
+
+Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,124 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[munoliver007@gmail.com](mailto:munoliver007@gmail.com).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Contributions to the [MB2CommunityEditor](https://github.com/YiGu-Studio/MB2CommunityEditor) project are most welcome!
+
+All `MB2CommunityEditor` pages are stored in Markdown right here on GitHub.
+Just open an issue or send a pull request and we'll incorporate it as soon as possible.
+
+*Note*: when submitting a new feature or bug fix, don't forget to check if there's already a pull request in progress for it.
+
+## Bug Reporting
+
+Your code doesn't work, and you have determined that the issue lies with `MB2CommunityEditor`? Follow these steps to report a bug.
+
+1. Your bug may already be fixed. Make sure to update to the current MB2CommunityEditor master branch.
+
+2. Search for similar issues. Make sure to delete is:open on the issue search to find solved tickets as well. It's possible somebody has encountered this bug already. Also remember to check out MB2CommunityEditor' FAQ. Still having a problem? Open an issue on Github.
+
+3. Make sure you provide us with useful information about your configuration: what OS are you using? What kind of operations you are doing. What is the expected output? What output you actually get?
+
+4. Provide us with a script or snapshot to reproduce the issue. We recommend that you use Github Gists to post your code. Any issue that cannot be reproduced is likely to be closed.
+
+If possible, take a stab at fixing the bug yourself --if you can!
+
+The more information you provide, the easier it is for us to validate that there is a bug and the faster we'll be able to take action. If you want your issue to be resolved quickly, following the steps above is crucial.
+
+## Requesting a Feature
+
+1. Provide a clear and detailed explanation of the feature you want and why it's important to add. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset.
+
+2. Provide code snippets demonstrating the API you have in mind and illustrating the use cases of your feature. Of course, you don't need to write any real code at this point!
+
+3. After discussing the feature you may choose to attempt a Pull Request. If you're at all able, start writing some code. We always have more work to do than time to do it. If you can write some code then that will speed the process along.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,34 @@
-# MB2Editor
-A **community**, **open-source**, **Unity3D based** Mount &amp; Blade II : Banner Lord module Editor
+# Mount &amp; Blade II : BannerLord Community Editor
 
-# Feature list
-- module data visual editor (**WIP**)
-- drag/drop modify tool
-- character/item/model preview
-- troop tree preview
-- build pipline (build/debug/deployment)
+A **community-driven**, **open-source**, **Unity3D based** Mount &amp; Blade II : BannerLord module Editor
 
-# Preview
-## Module Data Editor (Character)
+## Feature list
+
+* Module Data Visual Editor (**WIP**)
+* Drag/Drop Modify Tool
+* Character/Item/Model Preview
+* Troop Tree Preview
+* Build Pipline (build/debug/deployment)
+
+## Preview
+
+### Module Data Editor (Character)
 ![Module Data Editor Preview](Preview/character.gif)
+
+## Getting Started
+
+This is an Unity3D Based Project, please make sure you install [Unity3D](https://unity.com/).
+
+```
+git clone git@github.com:YiGu-Studio/MB2CommunityEditor.git
+```
+
+Open `MB2CommunityEditor` in `Unity3D` and get start!
+
+## How to Contribute
+
+Contributions are most welcome!
+
+* If you have any issues (Bugs/Feature Request/...), feel free to submit to [Issues](https://github.com/YiGu-Studio/MB2CommunityEditor/issues).
+
+* If you want to contribute to build this Editor, you can submit [Pull Requests](https://github.com/YiGu-Studio/MB2CommunityEditor/pulls). Have a look at the [contributing guidelines](CONTRIBUTING.md) and [code of conduct](CODE_OF_CONDUCT.md), and go ahead!


### PR DESCRIPTION
1. `Add` Contributing Guidelines
2. `Update` ReadMe
3. `Add` AllContributor Github Bot
4. `Add` Issues and Pull Requests Templates.